### PR TITLE
#2116: Copy-DbaServerAudit: Test Current Audit Filepath for Null

### DIFF
--- a/functions/Copy-DbaServerAudit.ps1
+++ b/functions/Copy-DbaServerAudit.ps1
@@ -164,7 +164,7 @@ function Copy-DbaServerAudit {
 				}
 			}
 
-			if ((Test-DbaSqlPath -SqlInstance $destServer -Path $currentAudit.Filepath) -eq $false) {
+			if (($currentAudit.Filepath) -ne $null -AND (Test-DbaSqlPath -SqlInstance $destServer -Path $currentAudit.Filepath) -eq $false) {
 				if ($Force -eq $false) {
 					Write-Message -Level Verbose -Message "$($currentAudit.Filepath) does not exist on $destination. Skipping $auditName. Specify -Force to create the directory."
 


### PR DESCRIPTION


<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Check the current audit filepath for null before testing the path to avoid error. This is a resolution to issue #2116 where this function is reporting "Cannot bind argument to parameter 'Path' because it is an empty string" when you try to copy an Audit that writes to the application log. 

### Approach
Changes will first test that the value of $currentAudit.Filepath is not null before testing the path for existence.
